### PR TITLE
Use CFLAGS and LDFLAGS when compile-chez-program builds itself

### DIFF
--- a/README
+++ b/README
@@ -23,7 +23,8 @@ installed anywhere specific, even building inside the repository should work.
 Once ChezScheme is ready, you can build chez-exe like so:
 
     scheme --script gen-config.ss [--prefix prefix] [--bindir bindir] \
-        [--libdir libdir] [--bootpath bootpath] [--scheme scheme]
+        [--libdir libdir] [--bootpath bootpath] [--scheme scheme] \
+        [...]
     make [bootpath=...] [libpath=...] [incdir=...] [scheme=...]
 
 Running gen-config.ss will create two files:
@@ -38,7 +39,8 @@ The options for gen-config are as follows:
 These --bindir and --libdir behave differently on unix and Windows. On Unix,
 --bindir defaults to $prefix/bin and --libdir to $prefix/lib, but on Windows
 they both default to $prefix. Additionally, the default for prefix on Unix is
-/usr/local while on Windows it is %LOCALAPPDATA%\chez-exe
+/usr/local while on Windows it is %LOCALAPPDATA%\chez-exe. The trailing
+arguments to gen-config.ss are stored to be passed to the C compiler.
 
 If you use gen-config to specify the bootpath, you may omit from the command
 line when invoking make. Otherwise, it is required. Bootpath indicates where

--- a/compile-chez-program.ss
+++ b/compile-chez-program.ss
@@ -3,6 +3,7 @@
 (include "utils.ss")
 
 (define chez-lib-dir (make-parameter "."))
+(define static-compiler-args (make-parameter '()))
 (define full-chez (make-parameter #f))
 (define gui (make-parameter #f))
 
@@ -59,7 +60,7 @@
 (generate-wpo-files #t)
 
 (define scheme-file (car args))
-(define compiler-args (cdr args))
+(define compiler-args (append (static-compiler-args) (cdr args)))
 
 (define mbits (format #f "-m~a" (machine-bits)))
 

--- a/gen-config.ss
+++ b/gen-config.ss
@@ -12,28 +12,32 @@
 (define libdir (make-parameter #f))
 (define bindir (make-parameter #f))
 
-(param-args (command-line-arguments)
-  [#f "--help" (lambda ()
-                 (printlns
-                   "gen-config.ss"
-                   " options:"
-                   "  --scheme: path to scheme exe"
-                   "  --bootpath: path to boot files"
-                   "  --prefix: root path for chez-exe installation"
-                   "  --libdir: path to location for install of chez-exe libraries"
-                   "  --bindir: path to location for install of chez-exe binaries"
-                   ""
-                   " On UNIX-like machines, bindir and libdir default to"
-                   " $prefix/bin and $prefix/lib respectively, and the default"
-                   " for prefix is /usr/local"
-                   " On Windows, bindir and libdir both default to $prefix, and the"
-                   " default for prefix is %LOCALAPPDATA%\\chez-exe")
-                 (exit))]
-  ["--scheme" scheme]
-  ["--bootpath" bootpath]
-  ["--prefix" prefixdir]
-  ["--libdir" libdir]
-  ["--bindir" bindir])
+(define args
+  (param-args (command-line-arguments)
+    [#f "--help" (lambda ()
+                   (printlns
+                     "Usage:"
+                     "gen-config.ss [--prefix prefix] [--bindir bindir]"
+                     "   [--libdir libdir] [--bootpath bootpath]"
+                     "   [--scheme scheme] [c-compiler-arg ...]"
+                     ""
+                     "  --scheme: path to scheme exe"
+                     "  --bootpath: path to boot files"
+                     "  --prefix: root path for chez-exe installation"
+                     "  --libdir: path to location for install of chez-exe libraries"
+                     "  --bindir: path to location for install of chez-exe binaries"
+                     ""
+                     " On UNIX-like machines, bindir and libdir default to"
+                     " $prefix/bin and $prefix/lib respectively, and the default"
+                     " for prefix is /usr/local"
+                     " On Windows, bindir and libdir both default to $prefix, and the"
+                     " default for prefix is %LOCALAPPDATA%\\chez-exe")
+                   (exit))]
+    ["--scheme" scheme]
+    ["--bootpath" bootpath]
+    ["--prefix" prefixdir]
+    ["--libdir" libdir]
+    ["--bindir" bindir]))
 
 (unless (libdir)
   (libdir
@@ -50,7 +54,8 @@
 
 (with-output-to-file "config.ss"
   (lambda ()
-    (write `(chez-lib-dir ,(libdir))))
+    (write `(chez-lib-dir ,(libdir)))
+    (write `(static-compiler-args ',args)))
   '(replace))
 
 (case (os-name)


### PR DESCRIPTION
This allows a user to pass -lz to the compiler, which is required on Debian.

Admittedly I didn't check if it's harmless to always pass -lz.