### PR TITLE
Provide flakification for chez-exe

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,59 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1681693905,
+        "narHash": "sha256-XdXMvCt+i2ZcmAIPZvu3RUwcdaC9OX7d1WMAJJokzeA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "db34d7561caa508ece0265a56f382c5d3b7a6c1b",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "utils": "utils"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1681202837,
+        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -7,6 +7,12 @@
     utils.lib.eachDefaultSystem (
       system: let
         pkgs = nixpkgs.legacyPackages.${system};
+        bootpath = if system == "x86_64-darwin"
+                   then "${pkgs.chez}/lib/csv${pkgs.chez.version}/ta6osx"
+                   else "${pkgs.chez}/lib/csv${pkgs.chez.version}/ta6le";
+        platformSpecificInputs = if system == "x86_64-darwin"
+                                 then [ pkgs.darwin.libiconv ]
+                                 else [ pkgs.libuuid ];
       in {
 
         packages.default = pkgs.stdenv.mkDerivation {
@@ -16,8 +22,7 @@
 
           buildInputs = with pkgs; [
             chez
-            libuuid
-          ];
+          ] ++ platformSpecificInputs;
 
           buildPhase = ''
             mkdir -p $out/{bin,lib}
@@ -25,7 +30,7 @@
             --prefix $out \
             --bindir $out/bin \
             --libdir $out/lib \
-            --bootpath ${pkgs.chez}/lib/csv${pkgs.chez.version}/ta6le \
+            --bootpath ${bootpath} \
             --scheme scheme
           '';
         };

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,34 @@
+{
+  inputs = {
+    utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, utils, ... }:
+    utils.lib.eachDefaultSystem (
+      system: let
+        pkgs = nixpkgs.legacyPackages.${system};
+      in {
+
+        packages.default = pkgs.stdenv.mkDerivation {
+          name = "chez-exe";
+          version = "0.0.1";
+          src = ./.;
+
+          buildInputs = with pkgs; [
+            chez
+            libuuid
+          ];
+
+          buildPhase = ''
+            mkdir -p $out/{bin,lib}
+            scheme --script gen-config.ss \
+            --prefix $out \
+            --bindir $out/bin \
+            --libdir $out/lib \
+            --bootpath ${pkgs.chez}/lib/csv9.5.8/ta6le \
+            --scheme scheme
+          '';
+        };
+      }
+    );
+}

--- a/flake.nix
+++ b/flake.nix
@@ -25,7 +25,7 @@
             --prefix $out \
             --bindir $out/bin \
             --libdir $out/lib \
-            --bootpath ${pkgs.chez}/lib/csv9.5.8/ta6le \
+            --bootpath ${pkgs.chez}/lib/csv${pkgs.chez.version}/ta6le \
             --scheme scheme
           '';
         };


### PR DESCRIPTION
### Flake.nix allows to simplify the build of compile-chez-program, full-chez.a, and petite-chez.a.
```
cd repoRoot
nix build
# result contains the bin and lib folder
ls -ahl result
```
### You can also can spawn a developer shell with a scheme-compiler:
```
nix develop
# new shell is spawned and 'scheme' is available
scheme
```
### chez-exe can now be used (as input) by other repositories through the flake-mechanism(https://nixos.wiki/wiki/Flakes)
example flake.nix of a repository which is not chez-exe
```
{
  inputs = {
    #before merge
    chez-exe.url = "github:rschardt/chez-exe";
    #after merge
    chez-exe.url = "github:gwatt/chez-exe";
  };
  outputs = {
    ...
  };
}
```